### PR TITLE
fixed error in gate definition for PiPhi

### DIFF
--- a/qiskit_research/utils/gates.py
+++ b/qiskit_research/utils/gates.py
@@ -157,7 +157,7 @@ class PiPhiGate(Gate):
         q = QuantumRegister(1, "q")
         qc = QuantumCircuit(q, name=self.name)
         rules = [
-            (RZGate(self.phi), [q[0], []]),
+            (RZGate(self.phi), [q[0]], []),
             (XGate(), [q[0]], []),
             (RZGate(-self.phi), [q[0]], []),
         ]


### PR DESCRIPTION
Correct minor error in definition of `PiPhiGate` that was making the `rules` invalid. Interestingly, unit tests on mock backends did not pick up on this, and it the error was only thrown when going through the `qiskit-ibm-provider` package, as when running on an actual backend.