### PR TITLE
upgrade for qiskit 1.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "qiskit-ibm-runtime",
     "qiskit-ibmq-provider",
     "qiskit-nature~=0.5",
-    "qiskit-terra==0.23",
+    "qiskit==0.46.0",
     "qiskit_sphinx_theme~=1.16.0",
 ]
 

--- a/qiskit_research/utils/dynamical_decoupling.py
+++ b/qiskit_research/utils/dynamical_decoupling.py
@@ -240,7 +240,8 @@ def add_pulse_calibrations(
         dag = circuit_to_dag(circuit)
         for run in dag.collect_runs(["pi_phi"]):
             for node in run:
-                qubit = node.qargs[0].index
+                # qubit = node.qargs[0].index
+                qubit = dag.find_bit(node.qargs[0]).index
                 phi = node.op.params[0]
                 x_sched = inst_sched_map.get("x", qubits=[qubit])
                 _, x_instruction = x_sched.instructions[0]

--- a/qiskit_research/utils/gate_decompositions.py
+++ b/qiskit_research/utils/gate_decompositions.py
@@ -102,8 +102,10 @@ class RZXtoEchoedCR(TransformationPass):
         dag: DAGCircuit,
     ) -> DAGCircuit:
         for rzx_run in dag.collect_runs(["rzx"]):
-            control = rzx_run[0].qargs[0].index
-            target = rzx_run[0].qargs[1].index
+            # control = rzx_run[0].qargs[0].index
+            # target = rzx_run[0].qargs[1].index
+            control = dag.find_bit(rzx_run[0].qargs[0]).index
+            target = dag.find_bit(rzx_run[0].qargs[1]).index
             cr_forward_dir = cr_forward_direction(
                 control, target, self._inst_map, self._ctrl_chans
             )

--- a/qiskit_research/utils/pauli_twirling.py
+++ b/qiskit_research/utils/pauli_twirling.py
@@ -107,7 +107,8 @@ class PauliTwirl(TransformationPass):
                 if node.op.name in TWO_QUBIT_PAULI_GENERATORS:
                     mini_dag = DAGCircuit()
                     q0, q1 = node.qargs
-                    mini_dag.add_qreg(q0.register)
+                    # mini_dag.add_qreg(q0.register)
+                    mini_dag.add_qreg(dag.find_bit(q0).registers[0][0])
 
                     theta = node.op.params[0]
                     this_pauli = Pauli(

--- a/qiskit_research/utils/pulse_scaling.py
+++ b/qiskit_research/utils/pulse_scaling.py
@@ -253,9 +253,21 @@ class ForceZZTemplateSubstitution(TransformationPass):
                         gp1 = next(dag.bfs_successors(rz_node))
                         if cx2_node in gp1[1]:
                             if (
-                                (cx1_node.qargs[0].index == cx2_node.qargs[0].index)
-                                and (cx1_node.qargs[1].index == cx2_node.qargs[1].index)
-                                and (cx2_node.qargs[1].index == rz_node.qargs[0].index)
+                                # (cx1_node.qargs[0].index == cx2_node.qargs[0].index)
+                                # and (cx1_node.qargs[1].index == cx2_node.qargs[1].index)
+                                # and (cx2_node.qargs[1].index == rz_node.qargs[0].index)
+                                (
+                                    dag.find_bit(cx1_node.qargs[0]).index
+                                    == dag.find_bit(cx2_node.qargs[0]).index
+                                )
+                                and (
+                                    dag.find_bit(cx1_node.qargs[1]).index
+                                    == dag.find_bit(cx2_node.qargs[1]).index
+                                )
+                                and (
+                                    dag.find_bit(cx2_node.qargs[1]).index
+                                    == dag.find_bit(rz_node.qargs[0]).index
+                                )
                             ):
                                 dag = self.sub_zz_in_dag(
                                     dag, cx1_node, rz_node, cx2_node


### PR DESCRIPTION
This starts making sure we have eliminated deprecation warnings for Qiskit 0.46 before checking that this causes no errors with Qiskit 1.0. This first commit fixes the deprecation of `index` and `register` for the `Qubit` class as discussed in this Qiskit [Issue](https://github.com/Qiskit/qiskit/issues/8922).