### PR TITLE
Fix CI

### DIFF
--- a/docs/apidocs/index.rst
+++ b/docs/apidocs/index.rst
@@ -7,5 +7,4 @@ Qiskit Research API Reference
 .. toctree::
    :maxdepth: 1
 
-   mzm_generation
    utils

--- a/docs/apidocs/mzm_generation.rst
+++ b/docs/apidocs/mzm_generation.rst
@@ -1,2 +1,0 @@
-.. automodule:: qiskit_research.mzm_generation
-   :members:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.25
-envlist = py{38,39,310}{,-notebook}, lint, mypy, format, coverage, docs
+envlist = py{38,39,310}, lint, mypy, format, coverage, docs
 isolated_build = True
 
 [testenv]
@@ -9,31 +9,29 @@ extras =
 commands =
   pytest test/ {posargs}
 
-[testenv:{py38-,py39-,py310-,}notebook]
-extras =
-  dev
-commands =
-  pytest --nbmake --nbmake-timeout=3000 {posargs} docs/
-
 [testenv:lint]
+base_python = 3.10
 extras =
   dev
 commands =
   pylint qiskit_research test
 
 [testenv:mypy]
+base_python = 3.10
 extras =
   dev
 commands =
   mypy --exclude=docs/_build .
 
 [testenv:format]
+base_python = 3.10
 extras =
   dev
 commands =
   black --check .
 
 [testenv:coverage]
+base_python = 3.10
 extras =
   dev
 commands =
@@ -43,6 +41,7 @@ commands =
   coverage3 report --fail-under=50
 
 [testenv:docs]
+base_python = 3.10
 extras =
   dev
 commands =
@@ -51,4 +50,4 @@ commands =
   sphinx-build -b html -W {posargs} docs/ docs/_build/html
 
 [pytest]
-addopts = --doctest-modules --ignore=docs/getting_started.ipynb
+addopts = --doctest-modules


### PR DESCRIPTION
- Remove notebook test which was failing because there are no notebooks being tested (I think this is redundant since sphinx also runs the notebooks anyway)
- Fix python version in tox environment
- Remove leftover references to `mzm_generation` module