### PR TITLE
removed mapomatic dependency 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
 requires-python = ">=3.8"
 
 dependencies = [
-    "mapomatic==0.9",
-    "qiskit==0.46.0",
+    "qiskit==1.1.1",
     "qiskit-aer",
     "qiskit-ibm-runtime",
 ]

--- a/qiskit_research/utils/convenience.py
+++ b/qiskit_research/utils/convenience.py
@@ -15,7 +15,7 @@ from typing import Any, Iterable, List, Optional, overload, Union
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import Gate
 from qiskit.circuit.library import XGate
-from qiskit.providers.backend import Backend
+from qiskit.providers import Backend
 from qiskit.transpiler import PassManager, Target
 from qiskit.transpiler.passes.scheduling import ALAPScheduleAnalysis
 from qiskit.transpiler.passes.scheduling.scheduling.base_scheduler import BaseScheduler
@@ -47,12 +47,12 @@ def add_dynamical_decoupling(
     """Add dynamical decoupling sequences and calibrations to circuits.
 
     Adds dynamical decoupling sequences and the calibrations necessary
-    to run them on an IBM backend.
+    to run them on an IBM backend target.
 
     Args:
         circuits (Union[QuantumCircuit, List[QuantumCircuit], List[List[QuantumCircuit]]]):
             input QuantumCircuit or sequences thereof.
-        backend (Backend): Backend to run on; gate timing is required for this method.
+        target (Target): Backend to run on; gate timing is required for this method.
         dd_str (str): String describing DD sequence to use.
         scheduler (BaseScheduler, optional): Scheduler, defaults to ALAPScheduleAnalysis.
         add_pulse_cals (bool, optional): Add Pulse calibrations for non-basis
@@ -168,7 +168,7 @@ def add_pauli_twirls(
 @overload
 def scale_cr_pulses(
     circuits: List[QuantumCircuit],
-    backend: Backend,
+    target: Target,
     unroll_rzx_to_ecr: Optional[bool] = True,
     force_zz_matches: Optional[bool] = True,
     param_bind: Optional[dict] = None,
@@ -178,7 +178,7 @@ def scale_cr_pulses(
 @overload
 def scale_cr_pulses(
     circuits: QuantumCircuit,
-    backend: Backend,
+    target: Target,
     unroll_rzx_to_ecr: Optional[bool] = True,
     force_zz_matches: Optional[bool] = True,
     param_bind: Optional[dict] = None,
@@ -187,7 +187,7 @@ def scale_cr_pulses(
 
 def scale_cr_pulses(
     circuits,
-    backend,
+    target,
     unroll_rzx_to_ecr: Optional[bool] = True,
     force_zz_matches: Optional[bool] = True,
     param_bind: Optional[dict] = None,
@@ -203,7 +203,7 @@ def scale_cr_pulses(
     pass_manager = PassManager(
         list(
             cr_scaling_passes(
-                backend,
+                target,
                 templates,
                 unroll_rzx_to_ecr=unroll_rzx_to_ecr,
                 force_zz_matches=force_zz_matches,
@@ -216,7 +216,7 @@ def scale_cr_pulses(
 
 def attach_cr_pulses(
     circuits: Union[QuantumCircuit, List[QuantumCircuit]],
-    backend: Backend,
+    target: Target,
     param_bind: dict,
 ) -> Union[QuantumCircuit, List[QuantumCircuit]]:
     """
@@ -224,7 +224,7 @@ def attach_cr_pulses(
     http://arxiv.org/abs/2012.11660. Binds parameters
     in param_bind and attaches pulse gates.
     """
-    pass_manager = PassManager(list(pulse_attaching_passes(backend, param_bind)))
+    pass_manager = PassManager(list(pulse_attaching_passes(target, param_bind)))
     return pass_manager.run(circuits)
 
 

--- a/qiskit_research/utils/convenience.py
+++ b/qiskit_research/utils/convenience.py
@@ -16,7 +16,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import Gate
 from qiskit.circuit.library import XGate
 from qiskit.providers.backend import Backend
-from qiskit.transpiler import PassManager
+from qiskit.transpiler import PassManager, Target
 from qiskit.transpiler.passes.scheduling import ALAPScheduleAnalysis
 from qiskit.transpiler.passes.scheduling.scheduling.base_scheduler import BaseScheduler
 
@@ -37,7 +37,7 @@ from qiskit_research.utils.dynamical_decoupling import (
 
 def add_dynamical_decoupling(
     circuits: Union[QuantumCircuit, List[QuantumCircuit], List[List[QuantumCircuit]]],
-    backend: Backend,
+    target: Target,
     dd_str: str,
     scheduler: BaseScheduler = ALAPScheduleAnalysis,
     add_pulse_cals: bool = False,
@@ -67,23 +67,22 @@ def add_dynamical_decoupling(
             single or sequence type of QuantumCircuit, shceduled with DD sequences
             inserted into idle times.
     """
-
     pass_manager = PassManager(
         list(
             dynamical_decoupling_passes(
-                backend, dd_str, scheduler, urdd_pulse_num=urdd_pulse_num
+                target, dd_str, scheduler, urdd_pulse_num=urdd_pulse_num
             )
         )
     )
     if isinstance(circuits, QuantumCircuit) or isinstance(circuits[0], QuantumCircuit):
         circuits_dd = pass_manager.run(circuits)
         if add_pulse_cals:
-            add_pulse_calibrations(circuits_dd, backend, pulse_method=pulse_method)
+            add_pulse_calibrations(circuits_dd, target, pulse_method=pulse_method)
     else:
         circuits_dd = [pass_manager.run(circs) for circs in circuits]
         if add_pulse_cals:
             for circs_dd in circuits_dd:
-                add_pulse_calibrations(circs_dd, backend, pulse_method=pulse_method)
+                add_pulse_calibrations(circs_dd, target, pulse_method=pulse_method)
 
     return circuits_dd
 

--- a/qiskit_research/utils/cost_funcs.py
+++ b/qiskit_research/utils/cost_funcs.py
@@ -15,10 +15,31 @@ from __future__ import annotations
 from typing import List, Tuple
 
 from qiskit.circuit import QuantumCircuit
+from qiskit.converters import circuit_to_dag
 from qiskit.providers.backend import Backend
-from qiskit.qasm import pi
+from qiskit.transpiler import Target
+from qiskit.transpiler.passes.layout.vf2_utils import (
+    build_average_error_map,
+    build_interaction_graph,
+    score_layout,
+)
 
+from math import pi
 import numpy as np
+
+
+def avg_error_score(qc_isa: QuantumCircuit, target: Target) -> float:
+    init_layout = qc_isa.layout.final_index_layout()
+    dag = circuit_to_dag(qc_isa)
+
+    layout = {idx: init_layout[idx] for idx in range(len(init_layout))}
+    avg_error_map = build_average_error_map(target, None, None)
+    im_graph, im_graph_node_map, reverse_im_graph_node_map, _ = build_interaction_graph(
+        dag, strict_direction=False
+    )
+    return score_layout(
+        avg_error_map, layout, im_graph_node_map, reverse_im_graph_node_map, im_graph
+    )
 
 
 def cost_func_scaled_cr(

--- a/qiskit_research/utils/cost_funcs.py
+++ b/qiskit_research/utils/cost_funcs.py
@@ -12,11 +12,8 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
-
 from qiskit.circuit import QuantumCircuit
 from qiskit.converters import circuit_to_dag
-from qiskit.providers.backend import Backend
 from qiskit.transpiler import Target
 from qiskit.transpiler.passes.layout.vf2_utils import (
     build_average_error_map,
@@ -24,11 +21,17 @@ from qiskit.transpiler.passes.layout.vf2_utils import (
     score_layout,
 )
 
-from math import pi
-import numpy as np
-
 
 def avg_error_score(qc_isa: QuantumCircuit, target: Target) -> float:
+    """Calculate average error score using vf2 utils
+
+    Args:
+        qc_isa (QuantumCircuit): transpiled circuit
+        target (Target): backend target
+
+    Returns:
+        float: average error score determined by average error map
+    """
     init_layout = qc_isa.layout.final_index_layout()
     dag = circuit_to_dag(qc_isa)
 
@@ -40,174 +43,3 @@ def avg_error_score(qc_isa: QuantumCircuit, target: Target) -> float:
     return score_layout(
         avg_error_map, layout, im_graph_node_map, reverse_im_graph_node_map, im_graph
     )
-
-
-def cost_func_scaled_cr(
-    circ: QuantumCircuit,
-    layouts: List[List[int]],
-    backend: Backend,
-) -> List[Tuple[List[int], float]]:
-    """
-    A custom cost function that includes T1 and T2 computed during idle periods,
-    for an already transpiled and scheduled circuit circ
-
-    Parameters:
-        circ (QuantumCircuit): scheduled circuit of interest
-        backend (IBMQBackend): An IBM Quantum backend instance
-
-    Returns:
-        float: error
-    """
-    out = []
-    props = backend.properties()
-    inst_sched_map = backend.defaults().instruction_schedule_map
-    dt = backend.configuration().dt
-    num_qubits = backend.configuration().num_qubits
-    t1s = [props.qubit_property(qq, "T1")[0] for qq in range(num_qubits)]
-    t2s = [props.qubit_property(qq, "T2")[0] for qq in range(num_qubits)]
-
-    error = 0.0
-    fid = 1.0
-    touched = set()
-    for layout in layouts:
-        for item in circ.data:
-            if item[0].num_qubits == 2:
-                q0 = circ.find_bit(item[1][0]).index
-                q1 = circ.find_bit(item[1][1]).index
-                if inst_sched_map.has("cx", qubits=[q0, q1]):
-                    basis_2q_error = props.gate_error("cx", [q0, q1])
-                elif inst_sched_map.has("ecr", qubits=[q0, q1]):
-                    basis_2q_error = props.gate_error("ecr", [q0, q1])
-                elif inst_sched_map.has("ecr", qubits=[q1, q0]):
-                    basis_2q_error = props.gate_error("ecr", [q1, q0])
-                else:
-                    print(
-                        f"{backend.name} missing 2Q gate between qubit pair ({q0}, {q1})"
-                    )
-
-            if item[0].name == "cx":
-                fid *= 1 - basis_2q_error
-                touched.add(q0)
-                touched.add(q1)
-
-            # if it is a scaled pulse derived from cx
-            elif item[0].name == "rzx":
-                cr_error = np.abs(float(item[0].params[0]) / (pi / 2)) * basis_2q_error
-
-                # assumes control qubit is actually control for cr
-                echo_error = props.gate_error("x", q0)
-
-                fid *= 1 - max(cr_error, 2 * echo_error)
-            elif item[0].name == "secr":
-                cr_error = (
-                    np.abs((float(item[0].params[0])) / (pi / 2)) * basis_2q_error
-                )
-
-                # assumes control qubit is actually control for cr
-                echo_error = props.gate_error("x", q0)
-
-                fid *= 1 - max(cr_error, echo_error)
-
-            elif item[0].name in ["sx", "x"]:
-                q0 = circ.find_bit(item[1][0]).index
-                fid *= 1 - props.gate_error(item[0].name, q0)
-                touched.add(q0)
-
-            # if it is a dynamical decoupling pulse
-            elif item[0].name in ["xp", "xm", "y", "yp", "ym"]:
-                q0 = circ.find_bit(item[1][0]).index
-                fid *= 1 - props.gate_error("x", q0)
-                touched.add(q0)
-
-            elif item[0].name == "measure":
-                q0 = circ.find_bit(item[1][0]).index
-                fid *= 1 - props.readout_error(q0)
-                touched.add(q0)
-
-            elif item[0].name == "delay":
-                q0 = circ.find_bit(item[1][0]).index
-                # Ignore delays that occur before gates
-                # This assumes you are in ground state and errors
-                # do not occur.
-                if q0 in touched:
-                    time = item[0].duration * dt
-                    fid *= 1 - idle_error(time, t1s[q0], t2s[q0])
-
-        error = 1 - fid
-        out.append((layout, error))
-    return out
-
-
-def idle_error(
-    time: float,
-    t1: float,
-    t2: float,
-) -> float:
-    """Compute the approx. idle error from T1 and T2
-    Parameters:
-        time (float): Delay time in sec
-        t1 (float): T1 time in sec
-        t2, (float): T2 time in sec
-    Returns:
-        float: Idle error
-    """
-    t2 = min(t1, t2)
-    rate1 = 1 / t1
-    rate2 = 1 / t2
-    p_reset = 1 - np.exp(-time * rate1)
-    p_z = (1 - p_reset) * (1 - np.exp(-time * (rate2 - rate1))) / 2
-    return p_z + p_reset
-
-
-def cost_func_ecr(
-    circ: QuantumCircuit,
-    layouts: List[List[int]],
-    backend: Backend,
-) -> List[Tuple[List[int], float]]:
-    """
-    A custom cost function that includes ECR gates in either direction
-
-    Parameters:
-        circ (QuantumCircuit): circuit of interest
-        layouts (list of lists): List of specified layouts
-        backend (IBMQBackend): An IBM Quantum backend instance
-
-    Returns:
-        list: Tuples of layout and cost
-    """
-    out = []
-    inst_sched_map = backend.defaults().instruction_schedule_map
-    props = backend.properties()
-    for layout in layouts:
-        error = 0.0
-        fid = 1.0
-        touched = set()
-        for item in circ.data:
-            if item[0].name == "ecr":
-                q0 = layout[circ.find_bit(item[1][0]).index]
-                q1 = layout[circ.find_bit(item[1][1]).index]
-                if inst_sched_map.has("ecr", [q0, q1]):
-                    fid *= 1 - props.gate_error("ecr", [q0, q1])
-                elif inst_sched_map.has("ecr", [q1, q0]):
-                    fid *= 1 - props.gate_error("ecr", [q1, q0])
-                else:
-                    print(
-                        f"{backend.name} does not support {item[0].name} \
-                        for qubit pair ({q0}, {q1})"
-                    )
-                touched.add(q0)
-                touched.add(q1)
-
-            elif item[0].name in ["sx", "x"]:
-                q0 = layout[circ.find_bit(item[1][0]).index]
-                fid *= 1 - props.gate_error(item[0].name, q0)
-                touched.add(q0)
-
-            elif item[0].name == "measure":
-                q0 = layout[circ.find_bit(item[1][0]).index]
-                fid *= 1 - props.readout_error(q0)
-                touched.add(q0)
-
-        error = 1 - fid
-        out.append((layout, error))
-    return out

--- a/qiskit_research/utils/dynamical_decoupling.py
+++ b/qiskit_research/utils/dynamical_decoupling.py
@@ -85,7 +85,7 @@ def dynamical_decoupling_passes(
     Yields:
         Iterator[Iterable[BasePass]]: Transpiler passes used for adding DD sequences.
     """
-    for new_gate in [Xp, Xm, Yp, Ym]:
+    for new_gate in cast(List[Gate], [Xp, Xm, Yp, Ym]):
         if new_gate.name not in target:
             target.add_instruction(new_gate, target["x"])
 

--- a/qiskit_research/utils/dynamical_decoupling.py
+++ b/qiskit_research/utils/dynamical_decoupling.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from enum import Enum
 from math import pi
-from typing import Iterable, List, Optional, Sequence, Union
+from typing import cast, Iterable, List, Optional, Sequence, Union
 
 import numpy as np
 from qiskit import QuantumCircuit, pulse
@@ -85,7 +85,7 @@ def dynamical_decoupling_passes(
     Yields:
         Iterator[Iterable[BasePass]]: Transpiler passes used for adding DD sequences.
     """
-    for new_gate in cast(List[Gate], [Xp, Xm, Yp, Ym]):
+    for new_gate in [cast(Gate, gate) for gate in [Xp, Xm, Yp, Ym]]:
         if new_gate.name not in target:
             target.add_instruction(new_gate, target["x"])
 

--- a/qiskit_research/utils/gate_decompositions.py
+++ b/qiskit_research/utils/gate_decompositions.py
@@ -32,10 +32,11 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
 from qiskit.pulse import ControlChannel, InstructionScheduleMap, Play
-from qiskit.qasm import pi
 from qiskit.transpiler.basepasses import TransformationPass
 
 from .gates import SECRGate
+
+from math import pi
 
 
 def cr_forward_direction(

--- a/qiskit_research/utils/gate_decompositions.py
+++ b/qiskit_research/utils/gate_decompositions.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from math import pi
 
 from qiskit import QuantumRegister
 from qiskit.circuit import ControlledGate, Gate, Qubit
@@ -29,56 +30,10 @@ from qiskit.circuit.library import (
     XXPlusYYGate,
 )
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.exceptions import QiskitError
-from qiskit.providers.backend import Backend
-from qiskit.pulse import ControlChannel, InstructionScheduleMap, Play
+from qiskit.transpiler import Target
 from qiskit.transpiler.basepasses import TransformationPass
 
 from .gates import SECRGate
-
-from math import pi
-
-
-def cr_forward_direction(
-    control: int,
-    target: int,
-    inst_sched_map: InstructionScheduleMap,
-    ctrl_chans: dict,
-) -> bool:
-    """
-    Determines if the direction of cross resonance is forward (True), applied on control qubit qc or
-    reverse (False), applied to target qubit qt.
-    """
-    if inst_sched_map.has("cx", qubits=[control, target]):
-        cr_sched = inst_sched_map.get("cx", qubits=[control, target])
-    elif inst_sched_map.has("ecr", qubits=[control, target]):
-        return True
-    elif inst_sched_map.has("ecr", qubits=[target, control]):
-        return False
-    else:
-        raise QiskitError(
-            f"Native direction cannot be determined between qubits {control} and {target}."
-        )
-    cr_ctrl_chan = (
-        cr_sched.filter(
-            channels=[
-                ControlChannel(idx)
-                for idx in range(len(inst_sched_map.qubits_with_instruction("cx")))
-            ],
-            instruction_types=Play,
-        )
-        .instructions[0][1]
-        .channel
-    )
-    forward_ctrl_chan = ctrl_chans[(control, target)][0]
-    reverse_ctrl_chan = ctrl_chans[(target, control)][0]
-
-    if cr_ctrl_chan == forward_ctrl_chan:
-        return True
-    if cr_ctrl_chan == reverse_ctrl_chan:
-        return False
-
-    raise ValueError(f"Qubits {control} and {target} are not a cross resonance pair.")
 
 
 class RZXtoEchoedCR(TransformationPass):
@@ -92,11 +47,10 @@ class RZXtoEchoedCR(TransformationPass):
 
     def __init__(
         self,
-        backend: Backend,
+        target: Target,
     ):
         super().__init__()
-        self._inst_map = backend.defaults().instruction_schedule_map
-        self._ctrl_chans = backend.configuration().control_channels
+        self._coupling_map = target.build_coupling_map()
 
     def run(
         self,
@@ -105,9 +59,13 @@ class RZXtoEchoedCR(TransformationPass):
         for rzx_run in dag.collect_runs(["rzx"]):
             control, _ = dag.find_bit(rzx_run[0].qargs[0])
             target, _ = dag.find_bit(rzx_run[0].qargs[1])
-            cr_forward_dir = cr_forward_direction(
-                control, target, self._inst_map, self._ctrl_chans
-            )
+            # cr_forward_dir = cr_forward_direction(
+            #     control, target, self._inst_map, self._ctrl_chans
+            # )
+            if (control, target) in self._coupling_map:
+                cr_forward_dir = (control, target)
+            else:
+                cr_forward_dir = (target, control)
 
             for node in rzx_run:
                 mini_dag = DAGCircuit()

--- a/qiskit_research/utils/gates.py
+++ b/qiskit_research/utils/gates.py
@@ -13,14 +13,13 @@
 from __future__ import annotations
 
 from typing import Optional
+from math import pi
 
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library import RZXGate, RZGate, U3Gate, XGate
 from qiskit.circuit.parameterexpression import ParameterValueType
-
-from math import pi
 
 
 class XpGate(Gate):
@@ -43,10 +42,6 @@ class XpGate(Gate):
             qc.append(instr, qargs, cargs)
 
         self.definition = qc
-
-    def inverse(self):
-        r"""Gate inverse."""
-        return XmGate()
 
     def __array__(self, dtype=None):
         """Gate matrix."""
@@ -74,10 +69,6 @@ class XmGate(Gate):
 
         self.definition = qc
 
-    def inverse(self):
-        r"""Gate inverse."""
-        return XpGate()
-
     def __array__(self, dtype=None):
         """Gate matrix"""
         return np.array([[0, 1], [1, 0]], dtype=dtype)
@@ -101,10 +92,6 @@ class YpGate(Gate):
 
         self.definition = qc
 
-    def inverse(self):
-        r"""Return inverted Yp gate (:math:`Y{\dagger} = Y`)"""
-        return YmGate()  # self-inverse
-
     def __array__(self, dtype=None):
         """Gate matrix."""
         return np.array([[0, -1j], [1j, 0]], dtype=dtype)
@@ -127,10 +114,6 @@ class YmGate(Gate):
             qc.append(instr, qargs, cargs)
 
         self.definition = qc
-
-    def inverse(self):
-        r"""Return inverted Ym gate (:math:`Y{\dagger} = Y`)"""
-        return YpGate()  # self-inverse
 
     def __array__(self, dtype=None):
         """Gate matrix."""
@@ -167,10 +150,6 @@ class PiPhiGate(Gate):
 
         self.definition = qc
 
-    def inverse(self):
-        r"""Return inverted PiPhi gate (:math:`\pi_\phi{\dagger}(\phi) = \pi_\phi(-\phi)`)"""
-        return PiPhiGate(-self.phi)  # self-inverse
-
     def __array__(self, dtype=None):
         """Gate matrix."""
         return np.cos(self.phi) * np.array([[0, 1], [1, 0]], dtype=dtype) + np.sin(
@@ -203,10 +182,6 @@ class SECRGate(Gate):
             qc.append(instr, qargs, cargs)
 
         self.definition = qc
-
-    def inverse(self):
-        r"""Gate inverse."""
-        return SECRGate(-self.params[0])
 
     def __array__(self, dtype=None):
         """Gate matrix."""

--- a/qiskit_research/utils/gates.py
+++ b/qiskit_research/utils/gates.py
@@ -19,7 +19,8 @@ from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.library import RZXGate, RZGate, U3Gate, XGate
 from qiskit.circuit.parameterexpression import ParameterValueType
-from qiskit.qasm import pi
+
+from math import pi
 
 
 class XpGate(Gate):

--- a/qiskit_research/utils/pulse_scaling.py
+++ b/qiskit_research/utils/pulse_scaling.py
@@ -26,7 +26,6 @@ from qiskit.pulse import (
     Schedule,
     ScheduleBlock,
 )
-from qiskit.qasm import pi
 from qiskit.transpiler.basepasses import BasePass, TransformationPass
 from qiskit.transpiler.passes import (
     CXCancellation,
@@ -40,6 +39,8 @@ from qiskit_research.utils.gate_decompositions import (
     RZXtoEchoedCR,
 )
 from qiskit_research.utils.gates import SECRGate
+
+from math import pi
 
 BASIS_GATES = ["sx", "rz", "rzx", "cx"]
 
@@ -71,14 +72,17 @@ def pulse_attaching_passes(
     param_bind: dict,
 ) -> Iterable[BasePass]:
     """Yields transpilation passes for attaching pulse schedules."""
-    inst_sched_map = backend.defaults().instruction_schedule_map
-    channel_map = backend.configuration().qubit_channel_mapping
+    # inst_sched_map = backend.defaults().instruction_schedule_map
+    # channel_map = backend.configuration().qubit_channel_mapping
+    target = backend.target
 
     yield BindParameters(param_bind)
     yield Optimize1qGatesDecomposition(BASIS_GATES)
     yield CXCancellation()
-    yield SECRCalibrationBuilder(inst_sched_map, channel_map)
-    yield RZXCalibrationBuilder(inst_sched_map, channel_map)
+    # yield SECRCalibrationBuilder(inst_sched_map, channel_map)
+    # yield RZXCalibrationBuilder(inst_sched_map, channel_map)
+    yield SECRCalibrationBuilder(target=target)
+    yield RZXCalibrationBuilder(target=target)
 
 
 class CombineRuns(TransformationPass):

--- a/qiskit_research/utils/pulse_scaling.py
+++ b/qiskit_research/utils/pulse_scaling.py
@@ -10,6 +10,7 @@
 
 """Pulse scaling."""
 
+from math import pi
 from typing import Iterable, List, Optional, Union
 
 from qiskit import pulse
@@ -19,16 +20,16 @@ from qiskit.circuit.library import CXGate, RZGate
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.dagcircuit import DAGCircuit, DAGNode, DAGOpNode
 from qiskit.exceptions import QiskitError
-from qiskit.providers.backend import Backend
 from qiskit.pulse import (
     ControlChannel,
     Play,
     Schedule,
     ScheduleBlock,
 )
+from qiskit.transpiler import Target
 from qiskit.transpiler.basepasses import BasePass, TransformationPass
 from qiskit.transpiler.passes import (
-    CXCancellation,
+    CommutativeCancellation,
     Optimize1qGatesDecomposition,
     RZXCalibrationBuilder,
     RZXCalibrationBuilderNoEcho,
@@ -40,13 +41,11 @@ from qiskit_research.utils.gate_decompositions import (
 )
 from qiskit_research.utils.gates import SECRGate
 
-from math import pi
-
 BASIS_GATES = ["sx", "rz", "rzx", "cx"]
 
 
 def cr_scaling_passes(
-    backend: Backend,
+    target: Target,
     templates: List[QuantumCircuit],
     unroll_rzx_to_ecr: bool = True,
     force_zz_matches: Optional[bool] = True,
@@ -59,28 +58,22 @@ def cr_scaling_passes(
     if force_zz_matches:
         yield ForceZZTemplateSubstitution()  # workaround for Terra Issue
     if unroll_rzx_to_ecr:
-        yield RZXtoEchoedCR(backend)
+        yield RZXtoEchoedCR(target)
     yield Optimize1qGatesDecomposition(BASIS_GATES)
-    yield CXCancellation()
+    yield CommutativeCancellation()
     yield CombineRuns(["rz"])
     if param_bind is not None:
-        yield from pulse_attaching_passes(backend, param_bind)
+        yield from pulse_attaching_passes(target, param_bind)
 
 
 def pulse_attaching_passes(
-    backend: Backend,
+    target: Target,
     param_bind: dict,
 ) -> Iterable[BasePass]:
     """Yields transpilation passes for attaching pulse schedules."""
-    # inst_sched_map = backend.defaults().instruction_schedule_map
-    # channel_map = backend.configuration().qubit_channel_mapping
-    target = backend.target
-
     yield BindParameters(param_bind)
     yield Optimize1qGatesDecomposition(BASIS_GATES)
-    yield CXCancellation()
-    # yield SECRCalibrationBuilder(inst_sched_map, channel_map)
-    # yield RZXCalibrationBuilder(inst_sched_map, channel_map)
+    yield CommutativeCancellation()
     yield SECRCalibrationBuilder(target=target)
     yield RZXCalibrationBuilder(target=target)
 
@@ -326,18 +319,18 @@ class SECRCalibrationBuilder(RZXCalibrationBuilderNoEcho):
         return secr_sched
 
 
-def get_ecr_pairs_from_backend(backend: Backend) -> List[List[int]]:
+def get_ecr_pairs_from_backend(target: Target) -> List[List[int]]:
     """
     Retrieve the coupling map of only CX defined be echoed cross resonance.
 
     Args:
-        backend (Backend): backend one desires the ECR coupling map from
+        target (Target): target one desires the ECR coupling map from
 
     Returns:
         List[List[int]]: coupling map consisting only of ECR pairs.
     """
-    coupling_map = backend.configuration().coupling_map
-    inst_sched_map = backend.defaults().instruction_schedule_map
+    coupling_map = target.build_coupling_map()
+    inst_sched_map = target.instruction_schedule_map()
 
     new_coupling_map = []
     for pair in coupling_map:

--- a/test/utils/test_cost_funcs.py
+++ b/test/utils/test_cost_funcs.py
@@ -8,133 +8,23 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Test pulse scaling."""
+"""Test cost function."""
 
 import unittest
 
-from mapomatic import deflate_circuit, evaluate_layouts, matching_layouts
-import numpy as np
-
-from qiskit import transpile
-from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit_ibm_runtime.fake_provider import FakeWashington
-
-from qiskit_research.utils.gates import SECRGate
-from qiskit_research.utils.convenience import (
-    add_dynamical_decoupling,
-    attach_cr_pulses,
-)
-from qiskit_research.utils.cost_funcs import cost_func_scaled_cr
+from qiskit.circuit import QuantumCircuit
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+from qiskit_ibm_runtime.fake_provider import FakeSherbrooke
+from qiskit_research.utils.cost_funcs import avg_error_score
 
 
 class TestScaledCostFuncs(unittest.TestCase):
-    """Test cost functions for scaled pulses."""
+    """Test cost function from vf2_utils"""
 
-    def test_cost_func_rzx(self):
-        """Test cost function for RZX"""
-        backend = FakeWashington()
-        rng = np.random.default_rng(12345)
-
-        phi = Parameter("$\\phi$")
-        theta = Parameter("$\\theta$")
-
-        qc = QuantumCircuit(3)
-        qc.rzx(theta, 0, 1)
-        qc.rzx(phi, 1, 2)
-
-        qc2 = qc.copy()
-        qc2.rzx(theta, 0, 1)
-        qc2.rzx(phi, 1, 2)
-
-        param_bind = {
-            phi: rng.uniform(0.2, 0.8),
-            theta: rng.uniform(0.2, 0.8),
-        }
-
-        qc_routed = transpile(qc, backend, optimization_level=3)
-        qc_bound = attach_cr_pulses(qc_routed, backend, param_bind=param_bind)
-        qc_sched = transpile(
-            qc_bound, backend, optimization_level=0, scheduling_method="alap"
-        )
-        layouts = matching_layouts(deflate_circuit(qc_sched), backend)
-        best_layout = evaluate_layouts(
-            deflate_circuit(qc_sched),
-            layouts,
-            backend,
-            cost_function=cost_func_scaled_cr,
-        )[0]
-
-        self.assertGreater(best_layout[1], 0)
-        self.assertLess(best_layout[1], 1)
-
-        qc2_routed = transpile(qc2, backend, initial_layout=best_layout[0])
-        qc2_bound = attach_cr_pulses(qc2_routed, backend, param_bind=param_bind)
-        qc2_sched = transpile(
-            qc2_bound, backend, optimization_level=0, scheduling_method="alap"
-        )
-        best_layout2 = evaluate_layouts(
-            deflate_circuit(qc2_sched),
-            best_layout[0],
-            backend,
-            cost_function=cost_func_scaled_cr,
-        )[0]
-
-        self.assertLess(best_layout[1], best_layout2[1])
-
-    def test_cost_func_secr(self):
-        """Test cost function for RZX"""
-        backend = FakeWashington()
-        rng = np.random.default_rng(12345)
-
-        phi = Parameter("$\\phi$")
-        theta = Parameter("$\\theta$")
-
-        qc = QuantumCircuit(3)
-        qc.append(SECRGate(theta), [0, 1])
-        qc.append(SECRGate(phi), [1, 2])
-
-        qc2 = qc.copy()
-        qc2.append(SECRGate(theta), [0, 1])
-        qc2.append(SECRGate(phi), [1, 2])
-
-        param_bind = {
-            phi: rng.uniform(0.2, 0.8),
-            theta: rng.uniform(0.2, 0.8),
-        }
-
-        qc_routed = transpile(qc, backend, optimization_level=3)
-        qc_bound = attach_cr_pulses(qc_routed, backend, param_bind=param_bind)
-        qc_sched = transpile(
-            qc_bound, backend, optimization_level=0, scheduling_method="alap"
-        )
-        layouts = matching_layouts(deflate_circuit(qc_sched), backend)
-        best_layout = evaluate_layouts(
-            deflate_circuit(qc_sched),
-            layouts,
-            backend,
-            cost_function=cost_func_scaled_cr,
-        )[0]
-
-        self.assertGreater(best_layout[1], 0)
-        self.assertLess(best_layout[1], 1)
-
-        qc2_routed = transpile(qc2, backend, initial_layout=best_layout[0])
-        qc2_bound = attach_cr_pulses(qc2_routed, backend, param_bind=param_bind)
-        qc2_sched = transpile(
-            qc2_bound, backend, optimization_level=0, scheduling_method="alap"
-        )
-        best_layout2 = evaluate_layouts(
-            deflate_circuit(qc2_sched),
-            best_layout[0],
-            backend,
-            cost_function=cost_func_scaled_cr,
-        )[0]
-
-        self.assertLess(best_layout[1], best_layout2[1])
-
-    def test_cost_func_dd(self):
-        """Test cost function for RZX"""
-        backend = FakeWashington()
+    def test_cost_func(self):
+        """Test average error cost function"""
+        backend = FakeSherbrooke()
+        target = backend.target
 
         qc = QuantumCircuit(5)
         qc.h(0)
@@ -145,30 +35,16 @@ class TestScaledCostFuncs(unittest.TestCase):
         qc2.cx(2, 3)
         qc2.cx(3, 4)
 
-        layout = [0, 1, 2, 3, 4]
-        qc_t = transpile(qc, backend, initial_layout=layout)
-        qc_dd = add_dynamical_decoupling(qc_t, backend, "XY4pm")
-        best_layout = evaluate_layouts(
-            qc_dd,
-            layout,
-            backend,
-            cost_function=cost_func_scaled_cr,
-        )[0]
+        pm = generate_preset_pass_manager(
+            target=target, optimization_level=2, seed_transpiler=12345
+        )
+        qc_t = pm.run(qc)
+        best_layout_score = avg_error_score(qc_t, target)
 
-        self.assertGreater(best_layout[1], 0)
-        self.assertLess(best_layout[1], 1)
+        self.assertGreater(best_layout_score, 0)
+        self.assertLess(best_layout_score, 1)
 
-        qc2_t = transpile(qc2, backend, initial_layout=layout)
-        qc2_dd = add_dynamical_decoupling(qc2_t, backend, "XY4pm")
-        best_layout2 = evaluate_layouts(
-            qc2_dd,
-            layout,
-            backend,
-            cost_function=cost_func_scaled_cr,
-        )[0]
+        qc2_t = pm.run(qc2)
+        best_layout_score2 = avg_error_score(qc2_t, target)
 
-        self.assertLess(best_layout[1], best_layout2[1])
-
-
-# TODO: Add unit test for ECR gate (i.e., ibm_sherbrooke) when resolved:
-# https://github.com/Qiskit/qiskit-terra/issues/9553
+        self.assertLess(best_layout_score, best_layout_score2)

--- a/test/utils/test_dynamical_decoupling.py
+++ b/test/utils/test_dynamical_decoupling.py
@@ -14,7 +14,7 @@ import unittest
 
 from qiskit import transpile
 from qiskit.circuit import QuantumCircuit
-from qiskit_ibm_runtime.fake_provider import FakeWashington
+from qiskit_ibm_runtime.fake_provider import FakeSherbrooke
 
 from qiskit_research.utils.convenience import (
     add_dynamical_decoupling,
@@ -37,7 +37,7 @@ class TestDynamicalDecoupling(unittest.TestCase):
         circuit.cx(0, 1)
         circuit.rx(1.0, [0, 1, 2])
 
-        backend = FakeWashington()
+        backend = FakeSherbrooke()
         transpiled = transpile(circuit, backend)
         transpiled_dd = add_dynamical_decoupling(
             transpiled, backend, "XY4pm", add_pulse_cals=True
@@ -59,7 +59,7 @@ class TestDynamicalDecoupling(unittest.TestCase):
         circuit.cx(0, 1)
         circuit.rx(1.0, [0, 1, 2])
 
-        backend = FakeWashington()
+        backend = FakeSherbrooke()
         transpiled = transpile(circuit, backend)
         transpiled_urdd4 = add_dynamical_decoupling(
             transpiled,
@@ -88,7 +88,7 @@ class TestDynamicalDecoupling(unittest.TestCase):
     def test_add_pulse_calibrations(self):
         """Test adding dynamical decoupling."""
         circuit = QuantumCircuit(2)
-        backend = FakeWashington()
+        backend = FakeSherbrooke()
         add_pulse_calibrations(circuit, backend)
         for key in circuit.calibrations["xp"]:
             drag_xp = circuit.calibrations["xp"][key].instructions[0][1].operands[0]

--- a/test/utils/test_pulse_scaling.py
+++ b/test/utils/test_pulse_scaling.py
@@ -22,7 +22,7 @@ from qiskit.pulse import Play
 from qiskit.quantum_info import Operator
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Optimize1qGatesDecomposition
-from qiskit_ibm_runtime.fake_provider import FakeMumbai
+from qiskit_ibm_runtime.fake_provider import FakeSherbrooke
 
 from qiskit_research.utils.convenience import scale_cr_pulses
 from qiskit_research.utils.gate_decompositions import RZXtoEchoedCR
@@ -37,7 +37,7 @@ from qiskit_research.utils.pulse_scaling import (
 class TestPulseScaling(unittest.TestCase):
     """Test pulse scaling."""
 
-    @data(FakeMumbai())  # TODO: add backend with ecr basis gate
+    @data(FakeSherbrooke())
     def test_rzx_to_secr_forward(self, backend: Backend):
         """Test pulse scaling RZX with forward SECR."""
         rng = np.random.default_rng()
@@ -67,7 +67,7 @@ class TestPulseScaling(unittest.TestCase):
 
         self.assertTrue(Operator(qc).equiv(Operator(scaled_qc)))
 
-    @data(FakeMumbai())  # TODO: add backend with ecr basis gate
+    @data(FakeSherbrooke())
     def test_rzx_to_secr_reverse(self, backend: Backend):
         """Test pulse scaling RZX with reverse SECR."""
         rng = np.random.default_rng()
@@ -98,7 +98,7 @@ class TestPulseScaling(unittest.TestCase):
 
         self.assertTrue(Operator(qc).equiv(Operator(scaled_qc)))
 
-    @data(FakeMumbai())  # TODO: add backend with ecr basis gate
+    @data(FakeSherbrooke())
     def test_rzx_to_secr(self, backend: Backend):
         """Test pulse scaling with RZX gates."""
         rng = np.random.default_rng()
@@ -116,7 +116,7 @@ class TestPulseScaling(unittest.TestCase):
         scaled_qc = scale_cr_pulses(qc, backend, unroll_rzx_to_ecr=True, param_bind={})
         self.assertTrue(Operator(qc).equiv(Operator(scaled_qc)))
 
-    @data(FakeMumbai())  # TODO: add backend with ecr basis gate
+    @data(FakeSherbrooke())
     def test_forced_rzz_template_match(self, backend: Backend):
         """Test forced template optimization for CX-RZ(1)-CX matches"""
         theta = Parameter("$\\theta$")
@@ -171,7 +171,7 @@ class TestPulseScaling(unittest.TestCase):
         self.assertAlmostEqual(qc2_s.data[0].operation.params[0], -1.9822971502571)
         self.assertAlmostEqual(qc3_s.data[0].operation.params[0], -np.pi)
 
-    @data(FakeMumbai())  # TODO: add backend with ecr basis gate
+    @data(FakeSherbrooke())
     def test_secr_calibration_builder(self, backend: Backend):
         """
         Test SECR Calibration Builder


### PR DESCRIPTION
Removed `mapomatic` dependency for upgrade to Qiskit 1.0, now using tools from `vf2_utils.py` for scoring. Additionally moved to `target` from `backend` in most cases (except `periodic_dynamical_decoupling` and others) to conform with how properties are pulled from backends going forward.

Closes #107.
Closes #114.
Closes #115.