### PR TITLE
Extended the gate set for pauli twirling

### DIFF
--- a/qiskit_research/utils/pauli_twirling.py
+++ b/qiskit_research/utils/pauli_twirling.py
@@ -11,14 +11,26 @@
 """Pauli twirling."""
 
 from typing import Any, Iterable, Optional
+from itertools import combinations
 
 import numpy as np
-from qiskit.circuit import QuantumRegister
+from qiskit.circuit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import (
     IGate,
     XGate,
     YGate,
     ZGate,
+    CXGate,
+    CYGate,
+    CZGate,
+    CHGate,
+    CSGate,
+    DCXGate,
+    CSXGate,
+    CSdgGate,
+    ECRGate,
+    iSwapGate,
+    SwapGate,
 )
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import BasePass, TransformationPass
@@ -26,13 +38,27 @@ from qiskit.transpiler.passes import (
     CXCancellation,
     Optimize1qGatesDecomposition,
 )
-from qiskit.quantum_info import Pauli, pauli_basis
+from qiskit.quantum_info import Pauli, Operator, pauli_basis
 from qiskit_research.utils.pulse_scaling import BASIS_GATES
 
+# Single qubit Pauli gates
 I = IGate()
 X = XGate()
 Y = YGate()
 Z = ZGate()
+
+# 2Q entangling gates
+CX = CXGate()  # cnot; controlled-X
+CY = CYGate()  # controlled-Y
+CZ = CZGate()  # controlled-Z
+CH = CHGate()  # controlled-Hadamard
+CS = CSGate()  # controlled-S
+DCX = DCXGate()  # double cnot
+CSX = CSXGate()  # controlled sqrt X
+CSdg = CSdgGate()  # controlled S^dagger
+ECR = ECRGate()  # echoed cross-resonance
+Swap = SwapGate()  # swap
+iSwap = iSwapGate()  # imaginary swap
 
 # this list consists of the 2-qubit rotation gates
 TWO_QUBIT_PAULI_GENERATORS = {
@@ -43,6 +69,63 @@ TWO_QUBIT_PAULI_GENERATORS = {
     "secr": Pauli("XZ"),
 }
 
+
+def create_pauli_twirling_sets(two_qubit_gate):
+    """Generate the Pauli twirling sets for a given 2Q gate.
+
+    Sets are ordered such that gate[0] and gate[1] are pre-rotations
+    applied to control and target, respectively. gate[2] and gate[3]
+    are post-rotations for control and target, respectively.
+
+    Parameters:
+        two_qubit_gate (Gate): Input two-qubit gate
+
+    Returns:
+        tuple: Tuple of all twirling gate sets
+    """
+
+    # Generate 16-element list of Pauli gates, each repeated 4 times
+    operator_list = [I, Z, X, Y] * 4
+    target_unitary = Operator(two_qubit_gate.to_matrix())
+    twirling_sets = []
+
+    # Generate combinations of 4 gates from the operator list
+    for gates in combinations(operator_list, 4):
+        qc = QuantumCircuit(2)
+        _build_twirl_circuit(qc, gates, two_qubit_gate)
+
+        norm = np.linalg.norm(Operator.from_circuit(qc) - target_unitary)
+        phase = _determine_phase(norm)
+
+        if phase is not None:
+            qc.global_phase += phase
+            # Verify the twirled circuit against the target unitary
+            assert Operator.from_circuit(qc) == target_unitary
+            twirl_set = (gates[0], gates[1]), (gates[2], gates[3])
+            if twirl_set not in twirling_sets:
+                twirling_sets.append(twirl_set)
+
+    return tuple(twirling_sets)
+
+
+def _build_twirl_circuit(qc, gates, two_qubit_gate):
+    """Build the twirled quantum circuit with specified gates."""
+    qc.append(gates[0], [0])
+    qc.append(gates[1], [1])
+    qc.append(two_qubit_gate, [0, 1])
+    qc.append(gates[2], [0])
+    qc.append(gates[3], [1])
+
+
+def _determine_phase(norm):
+    """Determine the phase based on the norm difference."""
+    if abs(norm) < 1e-15:
+        return 0
+    if abs(norm - 4) < 1e-15:
+        return np.pi
+    return None
+
+
 # this dictionary stores the twirl sets for each supported gate
 # each key is the name of a supported gate
 # each value is a tuple that represents the twirl set for the gate
@@ -50,24 +133,17 @@ TWO_QUBIT_PAULI_GENERATORS = {
 # "before" and "after" are tuples of single-qubit gates to be applied
 # before and after the gate to be twirled
 TWIRL_GATES = {
-    "cx": (
-        ((I, I), (I, I)),
-        ((I, X), (I, X)),
-        ((I, Y), (Z, Y)),
-        ((I, Z), (Z, Z)),
-        ((X, I), (X, X)),
-        ((X, X), (X, I)),
-        ((X, Y), (Y, Z)),
-        ((X, Z), (Y, Y)),
-        ((Y, I), (Y, X)),
-        ((Y, X), (Y, I)),
-        ((Y, Y), (X, Z)),
-        ((Y, Z), (X, Y)),
-        ((Z, I), (Z, I)),
-        ((Z, X), (Z, X)),
-        ((Z, Y), (I, Y)),
-        ((Z, Z), (I, Z)),
-    ),
+    "cx": create_pauli_twirling_sets(CX),
+    "cy": create_pauli_twirling_sets(CY),
+    "cz": create_pauli_twirling_sets(CZ),
+    "ch": create_pauli_twirling_sets(CH),
+    "cs": create_pauli_twirling_sets(CS),
+    "dcx": create_pauli_twirling_sets(DCX),
+    "csx": create_pauli_twirling_sets(CSX),
+    "csdg": create_pauli_twirling_sets(CSdg),
+    "ecr": create_pauli_twirling_sets(ECR),
+    "swap": create_pauli_twirling_sets(Swap),
+    "iswap": create_pauli_twirling_sets(iSwap),
 }
 
 

--- a/test/utils/test_pauli_twirling.py
+++ b/test/utils/test_pauli_twirling.py
@@ -39,7 +39,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cnot(self):
         """Test twirling CNOT."""
         twirl_gates = TWIRL_GATES["cx"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(CXGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -53,7 +53,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cy(self):
         """Test twirling CY"""
         twirl_gates = TWIRL_GATES["cy"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(CYGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -67,7 +67,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cz(self):
         """Test twirling CZ."""
         twirl_gates = TWIRL_GATES["cz"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(CZGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -81,7 +81,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_ch(self):
         """Test twirling CH."""
         twirl_gates = TWIRL_GATES["ch"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 4)
         operator = Operator(CHGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -95,7 +95,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cs(self):
         """Test twirling CS."""
         twirl_gates = TWIRL_GATES["cs"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 4)
         operator = Operator(CSGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -109,7 +109,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_dcx(self):
         """Test twirling DCX."""
         twirl_gates = TWIRL_GATES["dcx"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(DCXGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -123,7 +123,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_csx(self):
         """Test twirling CSX."""
         twirl_gates = TWIRL_GATES["csx"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 4)
         operator = Operator(CSXGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -137,7 +137,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_csdg(self):
         """Test twirling CSdg."""
         twirl_gates = TWIRL_GATES["csdg"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 4)
         operator = Operator(CSdgGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -151,7 +151,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_ecr(self):
         """Test twirling ECR."""
         twirl_gates = TWIRL_GATES["ecr"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(ECRGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -165,7 +165,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_swap(self):
         """Test twirling Swap."""
         twirl_gates = TWIRL_GATES["swap"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(SwapGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -179,7 +179,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_iswap(self):
         """Test twirling iSwap."""
         twirl_gates = TWIRL_GATES["iswap"]
-        self.assertGreater(len(twirl_gates), 0)
+        self.assertEqual(len(twirl_gates), 16)
         operator = Operator(iSwapGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)

--- a/test/utils/test_pauli_twirling.py
+++ b/test/utils/test_pauli_twirling.py
@@ -14,7 +14,19 @@ import unittest
 
 import numpy as np
 from qiskit.circuit import Parameter, QuantumCircuit
-from qiskit.circuit.library import CXGate
+from qiskit.circuit.library import (
+    CXGate,
+    CYGate,
+    CZGate,
+    CHGate,
+    CSGate,
+    DCXGate,
+    CSXGate,
+    CSdgGate,
+    ECRGate,
+    iSwapGate,
+    SwapGate,
+)
 from qiskit.quantum_info import Operator
 from qiskit_research.utils.convenience import add_pauli_twirls
 from qiskit_research.utils.gates import SECRGate
@@ -33,6 +45,136 @@ class TestPauliTwirling(unittest.TestCase):
             circuit.append(a, [0])
             circuit.append(b, [1])
             circuit.append(CXGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_cy(self):
+        """Test twirling CY"""
+        twirl_gates = TWIRL_GATES["cy"]
+        operator = Operator(CYGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(CYGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_cz(self):
+        """Test twirling CZ."""
+        twirl_gates = TWIRL_GATES["cz"]
+        operator = Operator(CZGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(CZGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_ch(self):
+        """Test twirling CH."""
+        twirl_gates = TWIRL_GATES["ch"]
+        operator = Operator(CHGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(CHGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_cs(self):
+        """Test twirling CS."""
+        twirl_gates = TWIRL_GATES["cs"]
+        operator = Operator(CSGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(CSGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_dcx(self):
+        """Test twirling DCX."""
+        twirl_gates = TWIRL_GATES["dcx"]
+        operator = Operator(DCXGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(DCXGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_csx(self):
+        """Test twirling CSX."""
+        twirl_gates = TWIRL_GATES["csx"]
+        operator = Operator(CSXGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(CSXGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_csdg(self):
+        """Test twirling CSdg."""
+        twirl_gates = TWIRL_GATES["csdg"]
+        operator = Operator(CSdgGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(CSdgGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_ecr(self):
+        """Test twirling ECR."""
+        twirl_gates = TWIRL_GATES["ecr"]
+        operator = Operator(ECRGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(ECRGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_swap(self):
+        """Test twirling Swap."""
+        twirl_gates = TWIRL_GATES["swap"]
+        operator = Operator(SwapGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(SwapGate(), [0, 1])
+            circuit.append(c, [0])
+            circuit.append(d, [1])
+            self.assertTrue(Operator(circuit).equiv(operator))
+
+    def test_twirl_gates_iswap(self):
+        """Test twirling iSwap."""
+        twirl_gates = TWIRL_GATES["iswap"]
+        operator = Operator(iSwapGate())
+        for (a, b), (c, d) in twirl_gates:
+            circuit = QuantumCircuit(2)
+            circuit.append(a, [0])
+            circuit.append(b, [1])
+            circuit.append(iSwapGate(), [0, 1])
             circuit.append(c, [0])
             circuit.append(d, [1])
             self.assertTrue(Operator(circuit).equiv(operator))

--- a/test/utils/test_pauli_twirling.py
+++ b/test/utils/test_pauli_twirling.py
@@ -39,6 +39,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cnot(self):
         """Test twirling CNOT."""
         twirl_gates = TWIRL_GATES["cx"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CXGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -52,6 +53,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cy(self):
         """Test twirling CY"""
         twirl_gates = TWIRL_GATES["cy"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CYGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -65,6 +67,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cz(self):
         """Test twirling CZ."""
         twirl_gates = TWIRL_GATES["cz"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CZGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -78,6 +81,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_ch(self):
         """Test twirling CH."""
         twirl_gates = TWIRL_GATES["ch"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CHGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -91,6 +95,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_cs(self):
         """Test twirling CS."""
         twirl_gates = TWIRL_GATES["cs"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CSGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -104,6 +109,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_dcx(self):
         """Test twirling DCX."""
         twirl_gates = TWIRL_GATES["dcx"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(DCXGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -117,6 +123,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_csx(self):
         """Test twirling CSX."""
         twirl_gates = TWIRL_GATES["csx"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CSXGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -130,6 +137,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_csdg(self):
         """Test twirling CSdg."""
         twirl_gates = TWIRL_GATES["csdg"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(CSdgGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -143,6 +151,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_ecr(self):
         """Test twirling ECR."""
         twirl_gates = TWIRL_GATES["ecr"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(ECRGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -156,6 +165,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_swap(self):
         """Test twirling Swap."""
         twirl_gates = TWIRL_GATES["swap"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(SwapGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)
@@ -169,6 +179,7 @@ class TestPauliTwirling(unittest.TestCase):
     def test_twirl_gates_iswap(self):
         """Test twirling iSwap."""
         twirl_gates = TWIRL_GATES["iswap"]
+        self.assertGreater(len(twirl_gates), 0)
         operator = Operator(iSwapGate())
         for (a, b), (c, d) in twirl_gates:
             circuit = QuantumCircuit(2)


### PR DESCRIPTION
This pull request enhances the `pauli_twirling` utility by adding support for more two-qubit gates and refactoring the code to be more modular. It also includes comprehensive tests for the newly supported gates.

### Enhancements to `pauli_twirling` utility:

* [`qiskit_research/utils/pauli_twirling.py`](diffhunk://#diff-3ed26a78f61c3f0b75e0a211a3f5af8830c50254b53a840fc1c2f42de639e4d4R14-R62): Added support for multiple two-qubit gates by importing additional gate classes and defining corresponding gate instances.
* [`qiskit_research/utils/pauli_twirling.py`](diffhunk://#diff-3ed26a78f61c3f0b75e0a211a3f5af8830c50254b53a840fc1c2f42de639e4d4R72-R146): Introduced the `create_pauli_twirling_sets` function to dynamically generate Pauli twirling sets for any two-qubit gate, and updated the `TWIRL_GATES` dictionary to use this function.

### Testing enhancements:

* [`test/utils/test_pauli_twirling.py`](diffhunk://#diff-df511b4b207a6a16d61289c3cc777c767a4d2ce76f32bd0d93fd7ee8d3d1a284L17-R29): Added imports for the new gate classes to be tested.
* [`test/utils/test_pauli_twirling.py`](diffhunk://#diff-df511b4b207a6a16d61289c3cc777c767a4d2ce76f32bd0d93fd7ee8d3d1a284R52-R181): Added test cases for each newly supported two-qubit gate to verify correct implementation of Pauli twirling.

Additionally, I have run the tests using tox locally and have added some more tests for the utilities introduced. Also thanks to [this ](Quantum-Twirling
)repo that helped me out with this. This enhancement was discussed in[ Issue #120](https://github.com/qiskit-community/qiskit-research/issues/120), where I brought it up, and @kevinsung requested me to open a pull request. 